### PR TITLE
feat: login con Google (OAuth2/OIDC)

### DIFF
--- a/api/.env.testing
+++ b/api/.env.testing
@@ -34,3 +34,12 @@ USER_PASSWORD=test
 # JWT Authentication
 JWT_SECRET=sphere-test-jwt-secret-m3n8p2q5
 JWT_EXPIRATION=24h
+# SSO UVUS (Universidad de Sevilla)
+SSO_US_CAS_URL=http://localhost:9444/cas
+SSO_US_CALLBACK_URL=http://localhost:8080/api/v1/users/auth/sso/us/callback
+FRONTEND_URL=http://localhost:5173
+
+# Login social con Google (OAuth2/OIDC); vacio en testing, los tests mockean la libreria
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_CALLBACK_URL=http://localhost:8080/api/v1/users/auth/sso/google/callback

--- a/api/package.json
+++ b/api/package.json
@@ -32,6 +32,7 @@
     "dotenv": "^16.4.5",
     "express": "^4.18.2",
     "express-validator": "^7.2.1",
+    "google-auth-library": "^10.9.0",
     "helmet": "^8.0.0",
     "jsonwebtoken": "^9.0.3",
     "mongo-seeding": "^4.0.1",

--- a/api/pnpm-lock.yaml
+++ b/api/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       express-validator:
         specifier: ^7.2.1
         version: 7.3.2
+      google-auth-library:
+        specifier: ^10.9.0
+        version: 10.9.0
       helmet:
         specifier: ^8.0.0
         version: 8.1.0
@@ -1180,6 +1183,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
@@ -1313,6 +1320,9 @@ packages:
 
   bcryptjs@2.4.3:
     resolution: {integrity: sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -1517,6 +1527,10 @@ packages:
 
   currency-codes@2.2.0:
     resolution: {integrity: sha512-vpbQc5sEYHGdTVAYUhHnKv0DWiYLRvzl/KKyqeHzBh7HD/j3UlWoScpZ9tN/jG6w2feddWoObsBbaNVu5yDapg==}
+
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -1760,6 +1774,10 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
@@ -1805,6 +1823,10 @@ packages:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   formidable@3.5.4:
     resolution: {integrity: sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==}
     engines: {node: '>=14.0.0'}
@@ -1828,6 +1850,14 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gaxios@7.2.0:
+    resolution: {integrity: sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
 
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
@@ -1873,6 +1903,14 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
+  google-auth-library@10.9.0:
+    resolution: {integrity: sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -1909,6 +1947,10 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -2035,6 +2077,9 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -2344,6 +2389,15 @@ packages:
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -2944,6 +2998,10 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
@@ -3882,6 +3940,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -4005,6 +4065,8 @@ snapshots:
   base64-js@1.5.1: {}
 
   bcryptjs@2.4.3: {}
+
+  bignumber.js@9.3.1: {}
 
   binary-extensions@2.3.0: {}
 
@@ -4213,6 +4275,8 @@ snapshots:
     dependencies:
       first-match: 0.0.1
       nub: 0.0.0
+
+  data-uri-to-buffer@4.0.1: {}
 
   debug@2.6.9:
     dependencies:
@@ -4526,6 +4590,11 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   fflate@0.8.2: {}
 
   figures@3.2.0:
@@ -4583,6 +4652,10 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   formidable@3.5.4:
     dependencies:
       '@paralleldrive/cuid2': 2.3.1
@@ -4603,6 +4676,22 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gaxios@7.2.0:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.2.0
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   generator-function@2.0.1: {}
 
@@ -4660,6 +4749,19 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
+  google-auth-library@10.9.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.2.0
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -4691,6 +4793,13 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   iconv-lite@0.4.24:
     dependencies:
@@ -4821,6 +4930,10 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
 
   json-buffer@3.0.1: {}
 
@@ -5091,6 +5204,14 @@ snapshots:
   natural-compare@1.4.0: {}
 
   negotiator@0.6.3: {}
+
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-int64@0.4.0: {}
 
@@ -5800,6 +5921,8 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@7.0.0: {}
 

--- a/api/src/main/config/container.ts
+++ b/api/src/main/config/container.ts
@@ -21,6 +21,7 @@ import PermissionService from '../services/PermissionService';
 import UserSettingsService from '../services/UserSettingsService';
 import NotificationService from '../services/NotificationService';
 import ApiKeyService from '../services/ApiKeyService';
+import AuthProviderService from '../services/AuthProviderService';
 
 dotenv.config();
 
@@ -60,6 +61,7 @@ function initContainer(databaseType: string): AwilixContainer {
     userSettingsService: asClass(UserSettingsService).singleton(),
     notificationService: asClass(NotificationService).singleton(),
     apiKeyService: asClass(ApiKeyService).singleton(),
+    authProviderService: asClass(AuthProviderService).singleton(),
   });
   return container;
 }

--- a/api/src/main/config/permissions.ts
+++ b/api/src/main/config/permissions.ts
@@ -29,6 +29,13 @@ export const ROUTE_PERMISSIONS: RoutePermission[] = [
     methods: ['POST'],
     isPublic: true,
   },
+  // Login social (SSO UVUS, Google, …). Debe ir ANTES del catch-all /users/**:
+  // las reglas se evalúan en orden y la primera que casa gana.
+  {
+    path: '/users/auth/sso/**',
+    methods: ['GET'],
+    isPublic: true,
+  },
   {
     path: '/users/register',
     methods: ['POST'],

--- a/api/src/main/controllers/SSOController.ts
+++ b/api/src/main/controllers/SSOController.ts
@@ -1,0 +1,100 @@
+import crypto from 'crypto';
+import container from '../config/container';
+import AuthProviderService from '../services/AuthProviderService';
+import CacheService from '../services/CacheService';
+import { getProvider } from '../services/identity/providerRegistry';
+import { handleError } from '../utils/users/helpers';
+
+const FRONTEND_URL = () => process.env.FRONTEND_URL ?? 'http://localhost:5173';
+const SSO_CODE_TTL = 30; // seconds; single-use exchange code
+const SSO_STATE_TTL = 600; // seconds; OAuth2 CSRF state, single use
+
+/**
+ * Social login controller, generic over identity providers (/users/auth/sso/:provider/*).
+ * The provider translates its protocol (CAS ticket, OAuth2 code...) into a normalized
+ * profile; everything else (account resolution, one-time code, JWT) is common.
+ */
+class SSOController {
+  private authProviderService: AuthProviderService;
+  private cacheService: CacheService;
+
+  constructor() {
+    this.authProviderService = container.resolve('authProviderService');
+    this.cacheService = container.resolve('cacheService');
+    this.initiate = this.initiate.bind(this);
+    this.callback = this.callback.bind(this);
+    this.exchange = this.exchange.bind(this);
+  }
+
+  async initiate(req: any, res: any) {
+    const provider = getProvider(req.params.provider);
+    if (!provider) {
+      return res.status(404).json({ error: 'Unknown identity provider' });
+    }
+
+    // `state` is consumed by OAuth2 providers (Google); CAS ignores it. Only OAuth2
+    // providers need it stored: the callback checks it for CSRF protection.
+    const state = crypto.randomBytes(16).toString('hex');
+    if (provider.usesState) {
+      await this.cacheService.set(`sso:state:${state}`, '1', SSO_STATE_TTL);
+    }
+    return res.redirect(provider.buildLoginUrl(state));
+  }
+
+  async callback(req: any, res: any) {
+    const provider = getProvider(req.params.provider);
+    if (!provider) {
+      return res.redirect(`${FRONTEND_URL()}/sso/callback?sso_error=unknown_provider`);
+    }
+
+    try {
+      if (provider.usesState) {
+        const state = req.query.state;
+        const known = state && (await this.cacheService.get(`sso:state:${state}`));
+        if (!known) {
+          return res.redirect(`${FRONTEND_URL()}/sso/callback?sso_error=invalid_state`);
+        }
+        await this.cacheService.del(`sso:state:${state}`); // single use
+      }
+
+      const profile = await provider.handleCallback(req.query);
+      if (!profile) {
+        return res.redirect(`${FRONTEND_URL()}/sso/callback?sso_error=invalid_response`);
+      }
+
+      const { token } = await this.authProviderService.findOrCreateUser(profile);
+
+      // Never expose the JWT in a redirect URL: hand out a short-lived single-use
+      // code instead, which the frontend exchanges through a direct API call.
+      const code = crypto.randomBytes(16).toString('hex');
+      await this.cacheService.set(`sso:code:${code}`, { token }, SSO_CODE_TTL);
+
+      return res.redirect(`${FRONTEND_URL()}/sso/callback?code=${code}`);
+    } catch (err: any) {
+      console.error('[SSO] callback error:', err);
+      return res.redirect(`${FRONTEND_URL()}/sso/callback?sso_error=server_error`);
+    }
+  }
+
+  async exchange(req: any, res: any) {
+    const { code } = req.query;
+    if (!code) {
+      return res.status(400).json({ error: 'Missing code parameter' });
+    }
+
+    try {
+      const data = await this.cacheService.get(`sso:code:${code}`);
+      if (!data) {
+        return res.status(401).json({ error: 'Invalid or expired SSO code' });
+      }
+
+      await this.cacheService.del(`sso:code:${code}`); // single use
+      return res.json({ token: data.token });
+    } catch (err: any) {
+      const { status, message } = handleError(err);
+      return res.status(status).json({ error: message });
+    }
+  }
+}
+
+export default SSOController;

--- a/api/src/main/repositories/mongoose/models/UserMongoose.ts
+++ b/api/src/main/repositories/mongoose/models/UserMongoose.ts
@@ -23,6 +23,16 @@ const ApiKeySchema = new Schema(
   { _id: true }
 );
 
+const IdentitySchema = new Schema(
+  {
+    provider: { type: String, enum: ['us-sso', 'google'], required: true },
+    providerId: { type: String, required: true },
+    email: { type: String },
+    linkedAt: { type: Date, default: Date.now },
+  },
+  { _id: false }
+);
+
 const UserSettingsSchema = new Schema(
   {
     phone: { type: String },
@@ -72,8 +82,16 @@ const userSchema = new Schema(
     password: {
       type: String,
       minlength: 5,
-      required: true,
+      // Solo obligatoria para cuentas locales puras: las cuentas con identidad
+      // externa (SSO UVUS, Google) no tienen contraseña.
+      required: function (this: any) {
+        return !this.identities || this.identities.length === 0;
+      },
       select: false,
+    },
+    identities: {
+      type: [IdentitySchema],
+      default: [],
     },
     role: {
       type: String,
@@ -133,7 +151,8 @@ const userSchema = new Schema(
 
 userSchema.pre('save', async function (callback) {
   const user = this;
-  if (!user.isModified('password')) return callback();
+  // SSO accounts have no password: nothing to hash.
+  if (!user.isModified('password') || !user.password) return callback();
 
   user.password = await hashPassword(user.password);
 
@@ -161,6 +180,12 @@ export interface UserDocument extends Document {
   firstName: string;
   lastName: string;
   email: string;
+  identities: {
+    provider: 'us-sso' | 'google';
+    providerId: string;
+    email?: string;
+    linkedAt?: Date;
+  }[];
   settings?: {
     phone?: string;
     avatar?: string;
@@ -197,6 +222,10 @@ export interface UserDocument extends Document {
 }
 
 userSchema.index({ 'apiKeys.key': 1 });
+userSchema.index(
+  { 'identities.provider': 1, 'identities.providerId': 1 },
+  { unique: true, sparse: true }
+);
 
 const userModel = mongoose.model<UserDocument>('User', userSchema, 'users');
 

--- a/api/src/main/routes/SSORoutes.ts
+++ b/api/src/main/routes/SSORoutes.ts
@@ -1,0 +1,13 @@
+import express from 'express';
+import SSOController from '../controllers/SSOController';
+
+const loadSSORoutes = function (app: express.Application) {
+  const ssoController = new SSOController();
+  const baseUrl = (process.env.BASE_URL_PATH ?? '') + '/api/v1';
+
+  app.route(baseUrl + '/users/auth/sso/:provider/initiate').get(ssoController.initiate);
+  app.route(baseUrl + '/users/auth/sso/:provider/callback').get(ssoController.callback);
+  app.route(baseUrl + '/users/auth/sso/:provider/exchange').get(ssoController.exchange);
+};
+
+export default loadSSORoutes;

--- a/api/src/main/services/AuthProviderService.ts
+++ b/api/src/main/services/AuthProviderService.ts
@@ -1,0 +1,89 @@
+import container from '../config/container';
+import UserRepository from '../repositories/mongoose/UserRepository';
+import OrganizationService from './OrganizationService';
+import { ProviderProfile } from './identity/IdentityProvider';
+import { generateJwtToken, generateUserTokenDTO } from '../utils/users/helpers';
+
+/**
+ * Provider-agnostic account logic for social logins: finds or creates the SPHERE user
+ * behind a normalized ProviderProfile and issues a session JWT. Knows nothing about
+ * CAS, OAuth2 or any specific provider.
+ */
+class AuthProviderService {
+  private userRepository: UserRepository;
+  private organizationService: OrganizationService;
+
+  constructor() {
+    this.userRepository = container.resolve('userRepository');
+    this.organizationService = container.resolve('organizationService');
+  }
+
+  async findOrCreateUser(profile: ProviderProfile): Promise<{ token: string }> {
+    const { provider, providerId, email, emailVerified, firstName, lastName } = profile;
+
+    if (!email) {
+      throw new Error('INVALID DATA: identity provider did not supply an email');
+    }
+
+    // 1. Same external identity already linked to an account.
+    let user = await this.userRepository.findOne({
+      'identities.provider': provider,
+      'identities.providerId': providerId,
+    });
+
+    // 2. Link by email ONLY when the provider verifies email ownership (Google does,
+    //    the US CAS does not). Linking on unverified email would allow account takeover.
+    if (!user && emailVerified) {
+      const existing = await this.userRepository.findByEmail(email);
+      if (existing) {
+        await this.userRepository.updateById(existing.id, {
+          $push: { identities: { provider, providerId, email } },
+        });
+        user = await this.userRepository.findById(existing.id);
+      }
+    }
+
+    // 3. New account. Resolve username collisions BEFORE creating the personal
+    //    organization: its name derives from the username and duplicates throw CONFLICT.
+    if (!user) {
+      const username = await this.resolveFreeUsername(profile.suggestedUsername ?? providerId);
+
+      user = await this.userRepository.create({
+        username,
+        identities: [{ provider, providerId, email }],
+        firstName,
+        lastName,
+        email,
+        // Same default as local registration; aggregators expect the key to exist.
+        settings: { avatar: '' },
+        ...generateUserTokenDTO(),
+      });
+
+      // Business rule shared with local registration: every user has a personal
+      // organization. If this fails we must not leave a half-created account.
+      try {
+        await this.organizationService.ensurePersonalOrganizationForUser({
+          id: user.id,
+          username: user.username,
+        });
+      } catch (err) {
+        await this.userRepository.destroy(user.username);
+        throw err;
+      }
+    }
+
+    const token = generateJwtToken({ id: user!.id, username: user!.username, role: user!.role });
+    return { token };
+  }
+
+  private async resolveFreeUsername(base: string): Promise<string> {
+    if (!(await this.userRepository.findByUsername(base))) return base;
+    if (!(await this.userRepository.findByUsername(`${base}-us`))) return `${base}-us`;
+
+    let i = 2;
+    while (await this.userRepository.findByUsername(`${base}-${i}`)) i++;
+    return `${base}-${i}`;
+  }
+}
+
+export default AuthProviderService;

--- a/api/src/main/services/CacheService.ts
+++ b/api/src/main/services/CacheService.ts
@@ -21,6 +21,14 @@ class CacheService {
     return value ? JSON.parse(value) : null;
   }
 
+  async del(key: string) {
+    if (!this.redisClient) {
+      throw new Error('ERROR: Redis client not initialized');
+    }
+
+    await this.redisClient.del(key);
+  }
+
   async set(key: string, value: any, expirationInSeconds?: number) {
     if (!this.redisClient) {
       throw new Error('ERROR: Redis client not initialized');

--- a/api/src/main/services/FileService.ts
+++ b/api/src/main/services/FileService.ts
@@ -7,7 +7,7 @@ const appPort = process.env.SERVER_PORT || 3000
 const processFileUris = (object: any, uriPropertyNames: any) => {
   
   uriPropertyNames.forEach((prop: any) => {
-    if (Object.prototype.hasOwnProperty.call(object, prop) || Object.prototype.hasOwnProperty.call(object._doc, prop)) {
+    if (Object.prototype.hasOwnProperty.call(object, prop) || Object.prototype.hasOwnProperty.call(object._doc ?? {}, prop)) {
       const uri = object[prop];
       if (uri && getUriType(uri) === 'relative') {
         const absoluteUri = getAbsoluteFileUri(uri);

--- a/api/src/main/services/UserService.ts
+++ b/api/src/main/services/UserService.ts
@@ -129,6 +129,11 @@ class UserService {
       }
     }
 
+    // SSO accounts have no local password; bcrypt.compare throws on undefined hashes.
+    if (!user.password) {
+      throw new Error('INVALID DATA: Invalid credentials');
+    }
+
     const passwordValid = await bcrypt.compare(password, user.password);
 
     if (!passwordValid) {

--- a/api/src/main/services/identity/GoogleProvider.ts
+++ b/api/src/main/services/identity/GoogleProvider.ts
@@ -1,0 +1,66 @@
+import { OAuth2Client } from 'google-auth-library';
+import { IdentityProvider, ProviderProfile } from './IdentityProvider';
+
+const CLIENT_ID = () => process.env.GOOGLE_CLIENT_ID ?? '';
+const CLIENT_SECRET = () => process.env.GOOGLE_CLIENT_SECRET ?? '';
+const CALLBACK_URL = () =>
+  process.env.GOOGLE_CALLBACK_URL ??
+  `http://localhost:${process.env.SERVER_PORT ?? 8080}${process.env.BASE_URL_PATH ?? ''}/api/v1/users/auth/sso/google/callback`;
+
+/**
+ * Identity provider for Google (OAuth2 / OpenID Connect, authorization code flow).
+ *
+ * The callback exchanges the `code` for an `id_token` and verifies it with
+ * `verifyIdToken` (signature, issuer, audience, expiration) — no userinfo call needed:
+ * the OIDC claims (sub, email, email_verified, given_name, family_name) are enough.
+ * Requires GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET (see docs/social-login-google-prep.md
+ * §2 for the Google Cloud Console setup).
+ */
+export class GoogleProvider implements IdentityProvider {
+  name = 'google' as const;
+  usesState = true;
+
+  // Built per call so env changes (tests, dotenv load order) are always picked up.
+  private client(): OAuth2Client {
+    return new OAuth2Client(CLIENT_ID(), CLIENT_SECRET(), CALLBACK_URL());
+  }
+
+  buildLoginUrl(state: string): string {
+    return this.client().generateAuthUrl({
+      scope: ['openid', 'email', 'profile'],
+      state,
+      access_type: 'online',
+      prompt: 'select_account',
+    });
+  }
+
+  async handleCallback(query: Record<string, string>): Promise<ProviderProfile | null> {
+    const code = query.code;
+    if (!code) return null;
+
+    const client = this.client();
+    const { tokens } = await client.getToken(code);
+    if (!tokens.id_token) return null;
+
+    const ticket = await client.verifyIdToken({
+      idToken: tokens.id_token,
+      audience: CLIENT_ID(),
+    });
+    const payload = ticket.getPayload();
+    if (!payload?.sub || !payload.email) return null;
+
+    // Google's `sub` is a ~21-digit number, useless as a human-readable username:
+    // suggest the local part of the email instead (resolveFreeUsername handles clashes).
+    const emailLocalPart = payload.email.split('@')[0];
+
+    return {
+      provider: this.name,
+      providerId: payload.sub,
+      email: payload.email,
+      emailVerified: payload.email_verified === true,
+      firstName: payload.given_name ?? emailLocalPart,
+      lastName: payload.family_name ?? 'Google',
+      suggestedUsername: emailLocalPart,
+    };
+  }
+}

--- a/api/src/main/services/identity/IdentityProvider.ts
+++ b/api/src/main/services/identity/IdentityProvider.ts
@@ -1,0 +1,36 @@
+export type ProviderName = 'us-sso' | 'google';
+
+/**
+ * Normalized identity profile. Every external provider (CAS, OAuth2, ...) translates
+ * its raw response into this shape; the rest of the system never sees provider-specific
+ * data. Providers are responsible for resolving their own fallbacks/defaults.
+ */
+export interface ProviderProfile {
+  provider: ProviderName;
+  providerId: string;
+  email: string;
+  /** Whether the provider guarantees the email belongs to the user (Google: yes, US CAS: no). */
+  emailVerified: boolean;
+  firstName: string;
+  lastName: string;
+  /** Optional human-readable username base. Defaults to providerId when absent. */
+  suggestedUsername?: string;
+}
+
+export interface IdentityProvider {
+  name: ProviderName;
+
+  /**
+   * Whether the provider relies on the OAuth2 `state` parameter for CSRF protection.
+   * When true, the common layer stores the state on initiate and requires a matching,
+   * unexpired state on callback (single use). CAS providers don't need it: the ticket
+   * is single-use and validated server-side.
+   */
+  usesState: boolean;
+
+  /** Absolute URL to redirect the browser to for login. `state` is used by OAuth2 providers; CAS ignores it. */
+  buildLoginUrl(state: string): string;
+
+  /** Translates the callback query params (ticket | code) into a normalized profile, or null if invalid. */
+  handleCallback(query: Record<string, string>): Promise<ProviderProfile | null>;
+}

--- a/api/src/main/services/identity/UsCasProvider.ts
+++ b/api/src/main/services/identity/UsCasProvider.ts
@@ -1,0 +1,62 @@
+import { IdentityProvider, ProviderProfile } from './IdentityProvider';
+
+// Official US endpoints (sic.us.es → "Descripción y uso del servicio"):
+//   production:    https://sso.us.es/CAS/
+//   preproduction: https://ssopre.us.es/CAS/  (note the uppercase /CAS/ path)
+const CAS_BASE_URL = () => process.env.SSO_US_CAS_URL ?? 'https://sso.us.es/CAS';
+const CALLBACK_URL = () =>
+  process.env.SSO_US_CALLBACK_URL ??
+  `http://localhost:${process.env.SERVER_PORT ?? 8080}${process.env.BASE_URL_PATH ?? ''}/api/v1/users/auth/sso/us/callback`;
+
+/**
+ * Identity provider for the Universidad de Sevilla SSO (CAS protocol).
+ *
+ * The US SSO (adAS) supports CAS 1.0/2.0, so validation uses /serviceValidate.
+ * Attribute names (cas:mail, cas:givenName, cas:schacSn1...) are the ones assumed by
+ * previous research and MUST be verified against the real serviceValidate response
+ * (see docs/sso-uvus-design.md §11.10). Set SSO_DEBUG_XML=true to log the raw XML
+ * during preproduction testing and adjust the parsing if names differ.
+ */
+export class UsCasProvider implements IdentityProvider {
+  name = 'us-sso' as const;
+  usesState = false;
+
+  buildLoginUrl(_state: string): string {
+    // CAS does not use `state`: the ticket is single-use and validated server-side.
+    return `${CAS_BASE_URL()}/login?service=${encodeURIComponent(CALLBACK_URL())}`;
+  }
+
+  async handleCallback(query: Record<string, string>): Promise<ProviderProfile | null> {
+    const ticket = query.ticket;
+    if (!ticket) return null;
+
+    const validateUrl = `${CAS_BASE_URL()}/serviceValidate?ticket=${encodeURIComponent(ticket)}&service=${encodeURIComponent(CALLBACK_URL())}`;
+    const response = await fetch(validateUrl);
+    const xml = await response.text();
+
+    if (process.env.SSO_DEBUG_XML === 'true') {
+      console.log('[SSO][us-cas] raw serviceValidate response:\n', xml);
+    }
+
+    const userMatch = xml.match(/<cas:user>([^<]+)<\/cas:user>/);
+    if (!userMatch) return null;
+
+    const pick = (tag: string): string | null => {
+      const match = xml.match(new RegExp(`<cas:${tag}>([^<]+)</cas:${tag}>`));
+      return match ? match[1].trim() : null;
+    };
+
+    const uvus = userMatch[1].trim();
+    const lastName =
+      [pick('schacSn1'), pick('schacSn2')].filter(Boolean).join(' ') || pick('sn') || 'US';
+
+    return {
+      provider: this.name,
+      providerId: uvus,
+      email: pick('mail') ?? `${uvus}@alum.us.es`,
+      emailVerified: false, // the US does not guarantee email ownership
+      firstName: pick('givenName') ?? uvus,
+      lastName,
+    };
+  }
+}

--- a/api/src/main/services/identity/providerRegistry.ts
+++ b/api/src/main/services/identity/providerRegistry.ts
@@ -1,0 +1,16 @@
+import { GoogleProvider } from './GoogleProvider';
+import { IdentityProvider } from './IdentityProvider';
+import { UsCasProvider } from './UsCasProvider';
+
+/**
+ * Maps the `:provider` URL segment to its identity provider implementation.
+ * Adding a new social login = one implementation + one entry here.
+ */
+const providers: Record<string, IdentityProvider> = {
+  us: new UsCasProvider(),
+  google: new GoogleProvider(),
+};
+
+export function getProvider(name: string): IdentityProvider | null {
+  return providers[name] ?? null;
+}

--- a/api/src/main/types/models/User.ts
+++ b/api/src/main/types/models/User.ts
@@ -42,10 +42,18 @@ export interface LeanUser {
   firstName: string;
   lastName: string;
   email: string;
+  identities?: UserIdentity[];
   settings?: UserSettings;
   token?: string;
   tokenExpiration?: Date;
   apiKeys: ApiKey[];
+}
+
+export interface UserIdentity {
+  provider: 'us-sso' | 'google';
+  providerId: string;
+  email?: string;
+  linkedAt?: Date;
 }
 
 export type LeanUserWithApiKey = (Omit<LeanUser, 'apiKeys' | 'password'> & { apiKey: ApiKey })

--- a/api/src/test/unit-tests/google-provider.test.ts
+++ b/api/src/test/unit-tests/google-provider.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GoogleProvider } from '../../main/services/identity/GoogleProvider';
+
+const { generateAuthUrl, getToken, verifyIdToken } = vi.hoisted(() => ({
+  generateAuthUrl: vi.fn(),
+  getToken: vi.fn(),
+  verifyIdToken: vi.fn(),
+}));
+
+vi.mock('google-auth-library', () => ({
+  OAuth2Client: class {
+    generateAuthUrl = generateAuthUrl;
+    getToken = getToken;
+    verifyIdToken = verifyIdToken;
+  },
+}));
+
+const basePayload = {
+  sub: '110248495921238986420',
+  email: 'fran.garcia@gmail.com',
+  email_verified: true,
+  given_name: 'Fran',
+  family_name: 'García',
+};
+
+const mockTokenExchange = (payload: Partial<typeof basePayload> | null) => {
+  getToken.mockResolvedValue({ tokens: { id_token: 'jwt-from-google' } });
+  verifyIdToken.mockResolvedValue({ getPayload: () => payload });
+};
+
+describe('GoogleProvider', () => {
+  const provider = new GoogleProvider();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('buildLoginUrl', () => {
+    it('requests the OIDC scopes and forwards the CSRF state', () => {
+      generateAuthUrl.mockReturnValue('https://accounts.google.com/o/oauth2/v2/auth?...');
+
+      const url = provider.buildLoginUrl('state-123');
+
+      expect(url).toBe('https://accounts.google.com/o/oauth2/v2/auth?...');
+      expect(generateAuthUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scope: ['openid', 'email', 'profile'],
+          state: 'state-123',
+        }),
+      );
+    });
+  });
+
+  describe('handleCallback', () => {
+    it('returns null when no code is present', async () => {
+      const result = await provider.handleCallback({});
+      expect(result).toBeNull();
+      expect(getToken).not.toHaveBeenCalled();
+    });
+
+    it('returns null when the token exchange yields no id_token', async () => {
+      getToken.mockResolvedValue({ tokens: {} });
+      const result = await provider.handleCallback({ code: '4/abc' });
+      expect(result).toBeNull();
+      expect(verifyIdToken).not.toHaveBeenCalled();
+    });
+
+    it('maps the verified id_token claims into a ProviderProfile', async () => {
+      mockTokenExchange(basePayload);
+
+      const profile = await provider.handleCallback({ code: '4/abc' });
+
+      expect(getToken).toHaveBeenCalledWith('4/abc');
+      expect(verifyIdToken).toHaveBeenCalledWith(
+        expect.objectContaining({ idToken: 'jwt-from-google' }),
+      );
+      expect(profile).toEqual({
+        provider: 'google',
+        providerId: '110248495921238986420',
+        email: 'fran.garcia@gmail.com',
+        emailVerified: true,
+        firstName: 'Fran',
+        lastName: 'García',
+        suggestedUsername: 'fran.garcia',
+      });
+    });
+
+    it('returns null when the payload lacks sub or email', async () => {
+      mockTokenExchange({ ...basePayload, email: undefined } as any);
+      expect(await provider.handleCallback({ code: '4/abc' })).toBeNull();
+
+      mockTokenExchange(null);
+      expect(await provider.handleCallback({ code: '4/abc' })).toBeNull();
+    });
+
+    it('only marks the email verified when Google says so explicitly', async () => {
+      mockTokenExchange({ ...basePayload, email_verified: undefined } as any);
+      const profile = await provider.handleCallback({ code: '4/abc' });
+      expect(profile?.emailVerified).toBe(false);
+    });
+
+    it('falls back to the email local part when name claims are missing', async () => {
+      mockTokenExchange({ ...basePayload, given_name: undefined, family_name: undefined } as any);
+
+      const profile = await provider.handleCallback({ code: '4/abc' });
+
+      expect(profile?.firstName).toBe('fran.garcia');
+      expect(profile?.lastName).toBe('Google');
+    });
+  });
+});

--- a/frontend/src/modules/auth/api/usersApi.ts
+++ b/frontend/src/modules/auth/api/usersApi.ts
@@ -49,6 +49,21 @@ export function registerUser(formData: RegisterFormProps, setErrors: Function = 
     });
 }
 
+export function exchangeSsoCode(code: string): Promise<{ token: string }> {
+    return fetch(`${USERS_BASE_PATH}/auth/sso/us/exchange?code=${encodeURIComponent(code)}`, {
+        method: "GET",
+        headers: {
+            "Content-Type": "application/json",
+        },
+    }).then(async (response) => {
+        const parsedResponse = await response.json().catch(() => ({}));
+        if (!response.ok) {
+            throw new Error(parsedResponse.error || "SSO exchange failed");
+        }
+        return parsedResponse;
+    });
+}
+
 export function getCurrentUser(token: string): Promise<any> {
     return fetch(`${USERS_BASE_PATH}/me`, {
         method: "GET",

--- a/frontend/src/modules/auth/components/google-login-button/index.tsx
+++ b/frontend/src/modules/auth/components/google-login-button/index.tsx
@@ -1,0 +1,40 @@
+import { motion } from 'framer-motion';
+import { fadeUp } from '../auth-layout';
+
+const SSO_INITIATE_URL = `${import.meta.env.VITE_API_URL}/users/auth/sso/google/initiate`;
+
+/**
+ * "Continue with Google" button (OAuth2/OIDC). Plain anchor with a full page
+ * navigation, like the UVUS button: the OAuth flow relies on browser redirects.
+ * Rendered right below UvusLoginButton.
+ */
+export default function GoogleLoginButton() {
+  return (
+    <motion.div variants={fadeUp} className="mt-3">
+      <a
+        href={SSO_INITIATE_URL}
+        className="flex h-11 w-full items-center justify-center gap-2 rounded-lg border border-tp-input-border bg-tp-input-bg text-sm font-medium text-tp-ink transition-colors duration-200 hover:border-tp-primary"
+      >
+        <svg className="h-4 w-4" viewBox="0 0 24 24">
+          <path
+            fill="#4285F4"
+            d="M23.52 12.27c0-.85-.08-1.67-.22-2.45H12v4.63h6.46a5.52 5.52 0 0 1-2.4 3.62v3h3.88c2.27-2.09 3.58-5.17 3.58-8.8Z"
+          />
+          <path
+            fill="#34A853"
+            d="M12 24c3.24 0 5.96-1.07 7.94-2.91l-3.88-3.01c-1.07.72-2.45 1.15-4.06 1.15-3.13 0-5.78-2.11-6.72-4.95H1.27v3.11A12 12 0 0 0 12 24Z"
+          />
+          <path
+            fill="#FBBC05"
+            d="M5.28 14.28a7.22 7.22 0 0 1 0-4.56V6.61H1.27a12.01 12.01 0 0 0 0 10.78l4.01-3.11Z"
+          />
+          <path
+            fill="#EA4335"
+            d="M12 4.77c1.76 0 3.34.61 4.59 1.8l3.44-3.44A11.53 11.53 0 0 0 12 0 12 12 0 0 0 1.27 6.61l4.01 3.11C6.22 6.88 8.87 4.77 12 4.77Z"
+          />
+        </svg>
+        Continuar con Google
+      </a>
+    </motion.div>
+  );
+}

--- a/frontend/src/modules/auth/components/login-form/index.tsx
+++ b/frontend/src/modules/auth/components/login-form/index.tsx
@@ -6,6 +6,7 @@ import { useAuth } from '../../hooks/useAuth';
 import { useRouter } from '../../../core/hooks/useRouter';
 import { Link } from 'react-router-dom';
 import { fadeUp } from '../auth-layout';
+import GoogleLoginButton from '../google-login-button';
 
 export type LoginFormProps = {
   loginField: string;
@@ -61,6 +62,15 @@ const LoginForm: React.FC = () => {
         <p className="mt-2 text-sm text-tp-steel">
           Sign in to your account to continue
         </p>
+      </motion.div>
+
+      {/* SSO first, local login below the divider (UVUS disabled for now) */}
+      <GoogleLoginButton />
+
+      <motion.div variants={fadeUp} className="my-5 flex items-center gap-3">
+        <div className="h-px flex-1 bg-tp-input-border" />
+        <span className="text-xs text-tp-muted">or</span>
+        <div className="h-px flex-1 bg-tp-input-border" />
       </motion.div>
 
       {/* Error alert */}

--- a/frontend/src/modules/auth/components/register-form/index.tsx
+++ b/frontend/src/modules/auth/components/register-form/index.tsx
@@ -6,6 +6,7 @@ import { registerUser } from '../../api/usersApi';
 import { useAuth } from '../../hooks/useAuth';
 import { useRouter } from '../../../core/hooks/useRouter';
 import { fadeUp } from '../auth-layout';
+import GoogleLoginButton from '../google-login-button';
 
 export type RegisterFormProps = {
   firstName: string;
@@ -74,6 +75,15 @@ const RegisterForm: React.FC = () => {
         <p className="mt-2 text-sm text-tp-steel">
           Get started with SPHERE in just a few steps
         </p>
+      </motion.div>
+
+      {/* SSO first, local registration below the divider (UVUS disabled for now) */}
+      <GoogleLoginButton />
+
+      <motion.div variants={fadeUp} className="my-5 flex items-center gap-3">
+        <div className="h-px flex-1 bg-tp-input-border" />
+        <span className="text-xs text-tp-muted">or</span>
+        <div className="h-px flex-1 bg-tp-input-border" />
       </motion.div>
 
       {/* Error alert */}

--- a/frontend/src/modules/auth/pages/sso-callback/index.tsx
+++ b/frontend/src/modules/auth/pages/sso-callback/index.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useRef, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { useAuth } from '../../hooks/useAuth';
+import { useRouter } from '../../../core/hooks/useRouter';
+import { exchangeSsoCode } from '../../api/usersApi';
+
+// Error keys emitted by the backend SSOController in ?sso_error=
+const ERROR_MESSAGES: Record<string, string> = {
+  invalid_response: 'La validación con el proveedor de identidad falló.',
+  unknown_provider: 'Proveedor de identidad no reconocido.',
+  invalid_state: 'La sesión de autenticación expiró o no es válida. Inténtalo de nuevo.',
+  server_error: 'Error procesando el inicio de sesión.',
+};
+
+export default function SsoCallbackPage() {
+  const [params] = useSearchParams();
+  const { login } = useAuth();
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const started = useRef(false);
+
+  useEffect(() => {
+    if (started.current) return;
+    started.current = true;
+
+    const ssoError = params.get('sso_error');
+    if (ssoError) {
+      setError(ERROR_MESSAGES[ssoError] ?? 'Error de autenticación.');
+      return;
+    }
+
+    const code = params.get('code');
+    if (!code) {
+      setError('Falta el código de autenticación.');
+      return;
+    }
+
+    exchangeSsoCode(code)
+      .then(async ({ token }) => {
+        // The code is single-use; drop it from the URL/history before navigating.
+        window.history.replaceState({}, '', '/sso/callback');
+        await login(token);
+        router.push('/');
+      })
+      .catch((e: Error) => setError(e.message));
+  }, [params, login, router]);
+
+  if (error) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center p-6">
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900/50 dark:bg-red-950/50">
+          <p className="text-sm text-red-600 dark:text-red-400">
+            {error}{' '}
+            <Link to="/authentication" className="font-medium underline">
+              Volver al inicio de sesión
+            </Link>
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <p className="text-sm text-tp-steel">Iniciando sesión…</p>
+    </div>
+  );
+}

--- a/frontend/src/routes/router.tsx
+++ b/frontend/src/routes/router.tsx
@@ -26,6 +26,7 @@ import ResearchPage from '../modules/presentation/pages/research';
 import ContributionsPage from '../modules/presentation/pages/contributions';
 import PricingListPage from '../modules/pricing/pages/list';
 import AuthenticationPage from '../modules/auth/pages/authentication-page';
+import SsoCallbackPage from '../modules/auth/pages/sso-callback';
 import CardPage from '../modules/pricing/pages/card';
 import CreatePricingPage from '../modules/pricing/pages/create';
 import CollectionCardPage from '../modules/pricing/pages/collection-card';
@@ -88,6 +89,7 @@ export default function Router() {
       ),
       children: [
         { element: <AuthenticationPage />, path: '/authentication' },
+        { element: <SsoCallbackPage />, path: '/sso/callback' },
         {
           path: '/pricings',
           element: (


### PR DESCRIPTION
## Qué añade

Login social con Google en SPHERE, con un flujo SSO genérico reutilizable para futuros proveedores.

- **Backend**: endpoints `/users/auth/sso/:provider/{initiate,callback,exchange}`, `GoogleProvider` que valida el `id_token` con `google-auth-library`, protección CSRF con `state` de un solo uso en Redis, y JWT entregado mediante código de intercambio de un solo uso (nunca en la URL).
- **Cuentas**: modelo con `identities[]`, vinculación automática por email verificado y creación de usuarios sin contraseña local (con su organización personal).
- **Frontend**: botón "Continuar con Google" en login y registro, y página `/sso/callback`.

## Configuración

Requiere `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` y `GOOGLE_CALLBACK_URL` en el `.env` del api (credenciales de Google Cloud Console; el callback debe estar dado de alta como Authorized redirect URI).

## Tests

7 tests unitarios de `GoogleProvider` (suite completa: 150 pasando). Probado el flujo end-to-end en local.